### PR TITLE
Update nodetool rubberband on rollback

### DIFF
--- a/CadNodeTool/TOMsNodeTool.py
+++ b/CadNodeTool/TOMsNodeTool.py
@@ -101,7 +101,7 @@ class TOMsNodeTool(NodeTool, MapToolMixin):
         currLayer = self.iface.activeLayer()
         QgsMessageLog.logMessage("In TOMsNodeTool:onGeometryChanged. closestLayer: " + str(currLayer.name()), tag="TOMs panel")
 
-        currLayer.geometryChanged.disconnect()
+        currLayer.geometryChanged.disconnect(self.onGeometryChanged)
         QgsMessageLog.logMessage("In TOMsNodeTool:onGeometryChanged. geometryChange signal disconnected.", tag="TOMs panel")
 
         idxGeometryID = currLayer.fieldNameIndex("GeometryID")


### PR DESCRIPTION
Fixes an issue where after a rollback the rubberband of the nodetool would no longer be in sync with the layer.
In the background, the geometryChanged signal was not only disconnected from "our own" onGeometryChanged slot, but also from the nodetools internals, which led to the situation that the nodetool was no longer informed about geometry changes (by rollback etc).